### PR TITLE
Add back activation routine

### DIFF
--- a/can4docker/driver.py
+++ b/can4docker/driver.py
@@ -37,6 +37,13 @@ def dispatch(data):
     return resp
 
 
+@APPLICATION.route('/Plugin.Activate', methods=['POST'])
+def activate():
+    """ Activate Docker Plugin."""
+    LOGGER.debug("/Plugin.Activate")
+    return dispatch({"Implements": ["NetworkDriver"]})
+
+
 @APPLICATION.route('/NetworkDriver.GetCapabilities', methods=['POST'])
 def capabilities():
     """ Routes Docker Network '/NetworkDriver.GetCapabilities'."""


### PR DESCRIPTION
Activation routine was removed as part of 704dc10d8c, which doesn't
cause any issue when loading the plugin via a docker image, but when
running via a local plugin, it is still required by docker.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>